### PR TITLE
Remediating Support both double and single quotes #48

### DIFF
--- a/src/SpeechMarkdownGrammar.ts
+++ b/src/SpeechMarkdownGrammar.ts
@@ -117,6 +117,7 @@ export function speechMarkdownGrammar(myna: any): any {
     // (text)[key: "value"] or (text)[key: "value";]
     // (text)[key:'value';key;key:"value"]
     const colon = m.char(':').ws;
+
     const semicolon = m.char(';').ws;
     this.textModifierKey = m.keywords(
       'emphasis',
@@ -187,6 +188,7 @@ export function speechMarkdownGrammar(myna: any): any {
       m.digit,
       m.letter,
       m.hyphen,
+      m.space,
       ...ipaChars,
     ).oneOrMore.ast;
 
@@ -194,6 +196,7 @@ export function speechMarkdownGrammar(myna: any): any {
       m.digit,
       m.letter,
       m.hyphen,
+      m.space,
       ...ipaChars,
       "'",
     ).oneOrMore.ast;

--- a/src/SpeechMarkdownGrammar.ts
+++ b/src/SpeechMarkdownGrammar.ts
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 // tslint:disable-next-line: max-func-body-length
 export function speechMarkdownGrammar(myna: any): any {
@@ -6,12 +6,12 @@ export function speechMarkdownGrammar(myna: any): any {
   // Override parenthesis function to not use `.guardedSeq`
   // This sequence is too assertive, and may cause exceptions rather than just returning null
   m.parenthesized = (rule: any) => {
-    return m.seq("(", m.ws, rule, m.ws, ")").setType("parenthesized");
-  }
+    return m.seq('(', m.ws, rule, m.ws, ')').setType('parenthesized');
+  };
 
   // tslint:disable-next-line: typedef
   // tslint:disable-next-line: max-func-body-length
-  const g: any = new function () {
+  const g: any = new (function() {
     //         // Allows the "inline" to be referenced before it is defined.
     //         // This enables recursive definitions.
     //         this.inlineDelayed = m.delay(() => this.inline);
@@ -21,7 +21,6 @@ export function speechMarkdownGrammar(myna: any): any {
     //             if (end === undefined) { end = begin; }
     //             return m.seq(begin, this.inlineDelayed.unless(end).zeroOrMore, end);
     //         }
-
 
     // Plain text
     const specialCharSet = '[]()';
@@ -33,11 +32,29 @@ export function speechMarkdownGrammar(myna: any): any {
     const nonSpecialCharEmphasis = m.notChar(specialCharSet).unless(m.newLine);
     const quoteChar = m.notChar('"');
 
-    this.plainText = m.choice(m.digits, m.letters, ws, nonSpecialChar).oneOrMore.ast;
-    this.plainTextEmphasis = m.choice(m.digits, m.letters, ws, nonSpecialChar).oneOrMore.ast;
-    const plainTextChoice = m.choice(m.digits, m.letters, ws, nonSpecialCharEmphasis);
+    this.plainText = m.choice(
+      m.digits,
+      m.letters,
+      ws,
+      nonSpecialChar,
+    ).oneOrMore.ast;
+    this.plainTextEmphasis = m.choice(
+      m.digits,
+      m.letters,
+      ws,
+      nonSpecialChar,
+    ).oneOrMore.ast;
+    const plainTextChoice = m.choice(
+      m.digits,
+      m.letters,
+      ws,
+      nonSpecialCharEmphasis,
+    );
     this.plainTextModifier = plainTextChoice.oneOrMore.ast;
-    this.plainTextPhone = m.seq(m.parenthesized(m.digits), plainTextChoice.oneOrMore).ast;
+    this.plainTextPhone = m.seq(
+      m.parenthesized(m.digits),
+      plainTextChoice.oneOrMore,
+    ).ast;
     this.plainTextSpecialChars = m.choice(
       m.seq('(', plainTextChoice, ') '),
       m.seq('[', plainTextChoice, '] '),
@@ -45,11 +62,11 @@ export function speechMarkdownGrammar(myna: any): any {
     ).oneOrMore.ast;
 
     // Break
-    this.timeUnit = m.choice('s','ms').ast;
+    this.timeUnit = m.choice('s', 'ms').ast;
     this.fraction = m.seq('.', m.digit.zeroOrMore);
     this.number = m.seq(m.integer, this.fraction.opt).ast;
     this.time = m.seq(this.number, this.timeUnit).ast;
-    this.shortBreak = m.seq('[', this.time , ']').ast;
+    this.shortBreak = m.seq('[', this.time, ']').ast;
     // this.break = m.seq('[break:', this.time , ']').ast;
 
     // this.string = m.doubleQuoted(this.quoteChar.zeroOrMore).ast;
@@ -59,11 +76,40 @@ export function speechMarkdownGrammar(myna: any): any {
     // The emphasis tag should be preluded and followed by a not-letter-character.
     // Otherwise an example like above would be captured.
     const notLetterChar = m.not(m.letters);
-    this.shortEmphasisModerate = m.seq(notLetterChar, '+', this.plainTextEmphasis , '+', notLetterChar).ast;
-    this.shortEmphasisStrong = m.seq(notLetterChar, '++', this.plainTextEmphasis , '++', notLetterChar).ast;
-    this.shortEmphasisNone = m.seq(notLetterChar, '~', this.plainTextEmphasis , '~', notLetterChar).ast;
-    this.shortEmphasisReduced = m.seq(notLetterChar, '-', this.plainTextEmphasis , '-', notLetterChar).ast;
-    this.emphasis = m.choice(this.shortEmphasisModerate, this.shortEmphasisStrong, this.shortEmphasisNone, this.shortEmphasisReduced);
+    this.shortEmphasisModerate = m.seq(
+      notLetterChar,
+      '+',
+      this.plainTextEmphasis,
+      '+',
+      notLetterChar,
+    ).ast;
+    this.shortEmphasisStrong = m.seq(
+      notLetterChar,
+      '++',
+      this.plainTextEmphasis,
+      '++',
+      notLetterChar,
+    ).ast;
+    this.shortEmphasisNone = m.seq(
+      notLetterChar,
+      '~',
+      this.plainTextEmphasis,
+      '~',
+      notLetterChar,
+    ).ast;
+    this.shortEmphasisReduced = m.seq(
+      notLetterChar,
+      '-',
+      this.plainTextEmphasis,
+      '-',
+      notLetterChar,
+    ).ast;
+    this.emphasis = m.choice(
+      this.shortEmphasisModerate,
+      this.shortEmphasisStrong,
+      this.shortEmphasisNone,
+      this.shortEmphasisReduced,
+    );
 
     // Modifier
     // (text)[key] or (text)[key;]
@@ -72,30 +118,146 @@ export function speechMarkdownGrammar(myna: any): any {
     // (text)[key:'value';key;key:"value"]
     const colon = m.char(':').ws;
     const semicolon = m.char(';').ws;
-    this.textModifierKey = m.keywords('emphasis', 'address', 'number', 'characters', 'chars', 'expletive', 'bleep', 'fraction', 'interjection', 'ordinal', 'telephone', 'phone', 'unit', 'time', 'date', 'whisper', 'ipa', 'sub', 'vol', 'volume', 'rate', 'pitch', 'lang', 'voice', 'excited', 'disappointed').ast;
+    this.textModifierKey = m.keywords(
+      'emphasis',
+      'address',
+      'number',
+      'characters',
+      'chars',
+      'expletive',
+      'bleep',
+      'fraction',
+      'interjection',
+      'ordinal',
+      'telephone',
+      'phone',
+      'unit',
+      'time',
+      'date',
+      'whisper',
+      'ipa',
+      'sub',
+      'vol',
+      'volume',
+      'rate',
+      'pitch',
+      'lang',
+      'voice',
+      'excited',
+      'disappointed',
+    ).ast;
     // Special characters for <phoneme alphabet="ipa" ph="..."> tag
-    const ipaChars = ['.', "'", 'æ', '͡ʒ', 'ð', 'ʃ', '͡ʃ', 'θ', 'ʒ', 'ə', 'ɚ', 'aɪ', 'aʊ', 'ɑ',
-      'eɪ', 'ɝ', 'ɛ', 'ɪ', 'oʊ', 'ɔ', 'ɔɪ', 'ʊ', 'ʌ', 'ɒ', 'ɛə', 'ɪə', 'ʊə', 'ˈ', 'ˌ', 'ŋ', 'ɹ'];
-    this.textModifierText = m.choice(m.digit, m.letter, m.hyphen, ...ipaChars).oneOrMore.ast;
-    this.textModifierValue = m.seq(colon, m.choice(m.singleQuoted(this.textModifierText), m.doubleQuoted(this.textModifierText)))
-    this.textModifierKeyOptionalValue = m.seq(this.textModifierKey, this.textModifierValue.opt).ast;
-    this.modifier = m.bracketed(m.delimited(this.textModifierKeyOptionalValue.ws, semicolon));
+    // const ipaChars = ['.', "'", 'æ', '͡ʒ', 'ð', 'ʃ', '͡ʃ', 'θ', 'ʒ', 'ə', 'ɚ', 'aɪ', 'aʊ', 'ɑ',
+    //  'eɪ', 'ɝ', 'ɛ', 'ɪ', 'oʊ', 'ɔ', 'ɔɪ', 'ʊ', 'ʌ', 'ɒ', 'ɛə', 'ɪə', 'ʊə', 'ˈ', 'ˌ', 'ŋ', 'ɹ'];
+
+    const ipaChars = [
+      '.',
+      'æ',
+      '͡ʒ',
+      'ð',
+      'ʃ',
+      '͡ʃ',
+      'θ',
+      'ʒ',
+      'ə',
+      'ɚ',
+      'aɪ',
+      'aʊ',
+      'ɑ',
+      'eɪ',
+      'ɝ',
+      'ɛ',
+      'ɪ',
+      'oʊ',
+      'ɔ',
+      'ɔɪ',
+      'ʊ',
+      'ʌ',
+      'ɒ',
+      'ɛə',
+      'ɪə',
+      'ʊə',
+      'ˈ',
+      'ˌ',
+      'ŋ',
+      'ɹ',
+    ];
+
+    this.textModifierText = m.choice(
+      m.digit,
+      m.letter,
+      m.hyphen,
+      ...ipaChars,
+    ).oneOrMore.ast;
+
+    this.textModifierTextDoubleQuote = m.choice(
+      m.digit,
+      m.letter,
+      m.hyphen,
+      ...ipaChars,
+      "'",
+    ).oneOrMore.ast;
+
+    this.textModifierValue = m.seq(
+      colon,
+      m.choice(
+        m.singleQuoted(this.textModifierText),
+        m.doubleQuoted(this.textModifierTextDoubleQuote),
+      ),
+    );
+    this.textModifierKeyOptionalValue = m.seq(
+      this.textModifierKey,
+      this.textModifierValue.opt,
+    ).ast;
+    this.modifier = m.bracketed(
+      m.delimited(this.textModifierKeyOptionalValue.ws, semicolon),
+    );
 
     const textText = m.parenthesized(this.plainTextModifier);
-    const textTextPhone = m.parenthesized(this.plainTextPhone)
-    this.textModifier = m.seq(m.choice(textText, textTextPhone), this.modifier).ast
+    const textTextPhone = m.parenthesized(this.plainTextPhone);
+    this.textModifier = m.seq(
+      m.choice(textText, textTextPhone),
+      this.modifier,
+    ).ast;
 
     // Audio
     this.urlSpecialChar = m.char(':/.-_~?#[]@!+,;%=()');
     this.url = m.choice(m.digit, m.letter, this.urlSpecialChar).oneOrMore.ast;
-    this.audio = m.seq('![', m.choice(m.singleQuoted(this.url), m.doubleQuoted(this.url)), ']').ast;
+    this.audio = m.seq(
+      '![',
+      m.choice(m.singleQuoted(this.url), m.doubleQuoted(this.url)),
+      ']',
+    ).ast;
 
     // Section
-    this.sectionModifierKey = m.keywords('lang', 'voice', 'defaults', 'dj', 'newscaster', 'excited', 'disappointed').ast;
-    this.sectionModifierText = m.choice(m.digit, m.letter, m.hyphen).oneOrMore.ast;
-    this.sectionModifierValue = m.seq(colon, m.choice(m.singleQuoted(this.sectionModifierText), m.doubleQuoted(this.sectionModifierText)))
-    this.sectionModifierKeyOptionalValue = m.seq(this.sectionModifierKey, this.sectionModifierValue.opt).ast;
-    this.sectionModifier = m.bracketed(m.delimited(this.sectionModifierKeyOptionalValue.ws, semicolon));
+    this.sectionModifierKey = m.keywords(
+      'lang',
+      'voice',
+      'defaults',
+      'dj',
+      'newscaster',
+      'excited',
+      'disappointed',
+    ).ast;
+    this.sectionModifierText = m.choice(
+      m.digit,
+      m.letter,
+      m.hyphen,
+    ).oneOrMore.ast;
+    this.sectionModifierValue = m.seq(
+      colon,
+      m.choice(
+        m.singleQuoted(this.sectionModifierText),
+        m.doubleQuoted(this.sectionModifierText),
+      ),
+    );
+    this.sectionModifierKeyOptionalValue = m.seq(
+      this.sectionModifierKey,
+      this.sectionModifierValue.opt,
+    ).ast;
+    this.sectionModifier = m.bracketed(
+      m.delimited(this.sectionModifierKeyOptionalValue.ws, semicolon),
+    );
     this.section = m.seq('#', this.sectionModifier).ast;
 
     // values
@@ -106,18 +268,45 @@ export function speechMarkdownGrammar(myna: any): any {
     this.valueStrong = 'strong';
     this.valueXStrong = 'x-strong';
 
-    this.breakStrengthValue = m.choice(this.valueNone, this.valueXWeak, this.valueWeak,
-      this.valueMedium, this.valueStrong, this.valueXStrong).ast;
-    this.breakStrength = m.seq('[', 'break', ':',
-        m.choice(m.singleQuoted(this.breakStrengthValue), m.doubleQuoted(this.breakStrengthValue)),
-      ']').ast;
-    this.breakTime = m.seq('[', 'break', ':',
-        m.choice(m.singleQuoted(this.time), m.doubleQuoted(this.time)),
-      ']').ast;
+    this.breakStrengthValue = m.choice(
+      this.valueNone,
+      this.valueXWeak,
+      this.valueWeak,
+      this.valueMedium,
+      this.valueStrong,
+      this.valueXStrong,
+    ).ast;
+    this.breakStrength = m.seq(
+      '[',
+      'break',
+      ':',
+      m.choice(
+        m.singleQuoted(this.breakStrengthValue),
+        m.doubleQuoted(this.breakStrengthValue),
+      ),
+      ']',
+    ).ast;
+    this.breakTime = m.seq(
+      '[',
+      'break',
+      ':',
+      m.choice(m.singleQuoted(this.time), m.doubleQuoted(this.time)),
+      ']',
+    ).ast;
 
     this.any = m.advance;
-    this.inline = m.choice(this.textModifier, this.emphasis, this.shortBreak, this.breakStrength,
-        this.breakTime, this.audio, this.plainTextSpecialChars, this.plainText, this.any)
+    this.inline = m
+      .choice(
+        this.textModifier,
+        this.emphasis,
+        this.shortBreak,
+        this.breakStrength,
+        this.breakTime,
+        this.audio,
+        this.plainTextSpecialChars,
+        this.plainText,
+        this.any,
+      )
       .unless(m.newLine);
     this.lineEnd = m.newLine.or(m.assert(m.end)).ast;
     this.emptyLine = m.char(' \t').zeroOrMore.then(m.newLine).ast;
@@ -127,8 +316,8 @@ export function speechMarkdownGrammar(myna: any): any {
 
     this.content = m.choice(this.section, this.paragraph, this.emptyLine);
     this.document = this.content.zeroOrMore.ast;
-  }
+  })();
 
   // Register the grammar, providing a name and the default parse rule
-  return m.registerGrammar("speechmarkdown", g, g.document);
+  return m.registerGrammar('speechmarkdown', g, g.document);
 }

--- a/tests/ipa-standard.spec.ts
+++ b/tests/ipa-standard.spec.ts
@@ -3,7 +3,6 @@ import dedent from 'ts-dedent';
 import { SpeechMarkdown } from '../src/SpeechMarkdown';
 
 describe('ipa-standard', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
@@ -11,9 +10,8 @@ describe('ipa-standard', () => {
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -27,9 +25,8 @@ describe('ipa-standard', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -43,9 +40,8 @@ describe('ipa-standard', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -59,9 +55,7 @@ describe('ipa-standard', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
@@ -70,5 +64,4 @@ describe('ipa-standard', () => {
 
     expect(text).toBe(expected);
   });
-
 });

--- a/tests/lang-standard.spec.ts
+++ b/tests/lang-standard.spec.ts
@@ -3,22 +3,22 @@ import dedent from 'ts-dedent';
 import { SpeechMarkdown } from '../src/SpeechMarkdown';
 
 describe('lang-standard', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     In Paris, they pronounce it (Paris)[lang:"fr-FR"].
+    In Paris, they pronounce it (Paris)[lang:'fr-FR'].
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      In Paris, they pronounce it <lang xml:lang="fr-FR">Paris</lang>.
       In Paris, they pronounce it <lang xml:lang="fr-FR">Paris</lang>.
       </speak>
     `;
@@ -27,14 +27,14 @@ describe('lang-standard', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      In Paris, they pronounce it Paris.
       In Paris, they pronounce it Paris.
       </speak>
     `;
@@ -43,14 +43,14 @@ describe('lang-standard', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      In Paris, they pronounce it Paris.
       In Paris, they pronounce it Paris.
       </speak>
     `;
@@ -59,16 +59,14 @@ describe('lang-standard', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      In Paris, they pronounce it Paris.
       In Paris, they pronounce it Paris.
     `;
 
     expect(text).toBe(expected);
   });
-
 });

--- a/tests/pitch-standard.spec.ts
+++ b/tests/pitch-standard.spec.ts
@@ -81,6 +81,7 @@ describe('pitch-standard-x-low', () => {
 
   const markdown = dedent`
     A (xlow)[pitch:"x-low"] pitch
+    A (xlow)[pitch:'x-low'] pitch
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
@@ -91,6 +92,7 @@ describe('pitch-standard-x-low', () => {
 
     const expected = dedent`
       <speak>
+      A <prosody pitch="x-low">xlow</prosody> pitch
       A <prosody pitch="x-low">xlow</prosody> pitch
       </speak>
     `;
@@ -107,6 +109,7 @@ describe('pitch-standard-x-low', () => {
     const expected = dedent`
       <speak>
       A <prosody pitch="x-low">xlow</prosody> pitch
+      A <prosody pitch="x-low">xlow</prosody> pitch
       </speak>
     `;
 
@@ -122,6 +125,7 @@ describe('pitch-standard-x-low', () => {
     const expected = dedent`
       <speak>
       A xlow pitch
+      A xlow pitch
       </speak>
     `;
 
@@ -133,6 +137,7 @@ describe('pitch-standard-x-low', () => {
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      A xlow pitch
       A xlow pitch
     `;
 
@@ -145,6 +150,7 @@ describe('pitch-standard-low', () => {
 
   const markdown = dedent`
     A (low)[pitch:"low"] pitch
+    A (low)[pitch:'low'] pitch
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
@@ -155,6 +161,7 @@ describe('pitch-standard-low', () => {
 
     const expected = dedent`
       <speak>
+      A <prosody pitch="low">low</prosody> pitch
       A <prosody pitch="low">low</prosody> pitch
       </speak>
     `;
@@ -171,6 +178,7 @@ describe('pitch-standard-low', () => {
     const expected = dedent`
       <speak>
       A <prosody pitch="low">low</prosody> pitch
+      A <prosody pitch="low">low</prosody> pitch
       </speak>
     `;
 
@@ -186,6 +194,7 @@ describe('pitch-standard-low', () => {
     const expected = dedent`
       <speak>
       A low pitch
+      A low pitch
       </speak>
     `;
 
@@ -197,6 +206,7 @@ describe('pitch-standard-low', () => {
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      A low pitch
       A low pitch
     `;
 
@@ -209,6 +219,7 @@ describe('pitch-standard-x-high', () => {
 
   const markdown = dedent`
     A (xhigh)[pitch:"x-high"] pitch
+    A (xhigh)[pitch:'x-high'] pitch
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
@@ -219,6 +230,7 @@ describe('pitch-standard-x-high', () => {
 
     const expected = dedent`
       <speak>
+      A <prosody pitch="x-high">xhigh</prosody> pitch
       A <prosody pitch="x-high">xhigh</prosody> pitch
       </speak>
     `;
@@ -235,6 +247,7 @@ describe('pitch-standard-x-high', () => {
     const expected = dedent`
       <speak>
       A <prosody pitch="x-high">xhigh</prosody> pitch
+      A <prosody pitch="x-high">xhigh</prosody> pitch
       </speak>
     `;
 
@@ -250,6 +263,7 @@ describe('pitch-standard-x-high', () => {
     const expected = dedent`
       <speak>
       A xhigh pitch
+      A xhigh pitch
       </speak>
     `;
 
@@ -262,6 +276,7 @@ describe('pitch-standard-x-high', () => {
 
     const expected = dedent`
       A xhigh pitch
+      A xhigh pitch
     `;
 
     expect(text).toBe(expected);
@@ -273,6 +288,7 @@ describe('pitch-standard-high', () => {
 
   const markdown = dedent`
     A (high)[pitch:"high"] pitch
+    A (high)[pitch:'high'] pitch
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
@@ -283,6 +299,7 @@ describe('pitch-standard-high', () => {
 
     const expected = dedent`
       <speak>
+      A <prosody pitch="high">high</prosody> pitch
       A <prosody pitch="high">high</prosody> pitch
       </speak>
     `;
@@ -298,6 +315,7 @@ describe('pitch-standard-high', () => {
 
     const expected = dedent`
       <speak>
+      A <prosody pitch="high">high</prosody> pitch
       A <prosody pitch="high">high</prosody> pitch
       </speak>
     `;
@@ -314,6 +332,7 @@ describe('pitch-standard-high', () => {
     const expected = dedent`
       <speak>
       A high pitch
+      A high pitch
       </speak>
     `;
 
@@ -325,6 +344,7 @@ describe('pitch-standard-high', () => {
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      A high pitch
       A high pitch
     `;
 

--- a/tests/pitch-standard.spec.ts
+++ b/tests/pitch-standard.spec.ts
@@ -3,18 +3,17 @@ import dedent from 'ts-dedent';
 import { SpeechMarkdown } from '../src/SpeechMarkdown';
 
 describe('pitch-standard-medium', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     A (medium)[pitch] pitch 1
     A (medium)[pitch:"medium"] pitch 2
+    A (medium)[pitch:'medium'] pitch 3
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -22,6 +21,7 @@ describe('pitch-standard-medium', () => {
       <speak>
       A <prosody pitch="medium">medium</prosody> pitch 1
       A <prosody pitch="medium">medium</prosody> pitch 2
+      A <prosody pitch="medium">medium</prosody> pitch 3
       </speak>
     `;
 
@@ -29,9 +29,8 @@ describe('pitch-standard-medium', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -39,6 +38,7 @@ describe('pitch-standard-medium', () => {
       <speak>
       A <prosody pitch="medium">medium</prosody> pitch 1
       A <prosody pitch="medium">medium</prosody> pitch 2
+      A <prosody pitch="medium">medium</prosody> pitch 3
       </speak>
     `;
 
@@ -46,9 +46,8 @@ describe('pitch-standard-medium', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -56,6 +55,7 @@ describe('pitch-standard-medium', () => {
       <speak>
       A medium pitch 1
       A medium pitch 2
+      A medium pitch 3
       </speak>
     `;
 
@@ -63,23 +63,20 @@ describe('pitch-standard-medium', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
       A medium pitch 1
       A medium pitch 2
+      A medium pitch 3
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('pitch-standard-x-low', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
@@ -87,9 +84,8 @@ describe('pitch-standard-x-low', () => {
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -103,9 +99,8 @@ describe('pitch-standard-x-low', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -119,9 +114,8 @@ describe('pitch-standard-x-low', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -135,9 +129,7 @@ describe('pitch-standard-x-low', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
@@ -146,11 +138,9 @@ describe('pitch-standard-x-low', () => {
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('pitch-standard-low', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
@@ -158,9 +148,8 @@ describe('pitch-standard-low', () => {
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -174,9 +163,8 @@ describe('pitch-standard-low', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -190,9 +178,8 @@ describe('pitch-standard-low', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -206,9 +193,7 @@ describe('pitch-standard-low', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
@@ -217,11 +202,9 @@ describe('pitch-standard-low', () => {
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('pitch-standard-x-high', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
@@ -229,9 +212,8 @@ describe('pitch-standard-x-high', () => {
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -245,9 +227,8 @@ describe('pitch-standard-x-high', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -261,9 +242,8 @@ describe('pitch-standard-x-high', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -277,9 +257,7 @@ describe('pitch-standard-x-high', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
@@ -288,11 +266,9 @@ describe('pitch-standard-x-high', () => {
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('pitch-standard-high', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
@@ -300,9 +276,8 @@ describe('pitch-standard-high', () => {
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -316,9 +291,8 @@ describe('pitch-standard-high', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -332,9 +306,8 @@ describe('pitch-standard-high', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -348,9 +321,7 @@ describe('pitch-standard-high', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
@@ -359,5 +330,4 @@ describe('pitch-standard-high', () => {
 
     expect(text).toBe(expected);
   });
-
 });

--- a/tests/rate-standard.spec.ts
+++ b/tests/rate-standard.spec.ts
@@ -3,18 +3,17 @@ import dedent from 'ts-dedent';
 import { SpeechMarkdown } from '../src/SpeechMarkdown';
 
 describe('rate-standard-medium', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     A (medium)[rate] rate 1
     A (medium)[rate:"medium"] rate 2
+    A (medium)[rate:'medium'] rate 3
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -22,6 +21,7 @@ describe('rate-standard-medium', () => {
       <speak>
       A <prosody rate="medium">medium</prosody> rate 1
       A <prosody rate="medium">medium</prosody> rate 2
+      A <prosody rate="medium">medium</prosody> rate 3
       </speak>
     `;
 
@@ -29,9 +29,8 @@ describe('rate-standard-medium', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -39,6 +38,7 @@ describe('rate-standard-medium', () => {
       <speak>
       A <prosody rate="medium">medium</prosody> rate 1
       A <prosody rate="medium">medium</prosody> rate 2
+      A <prosody rate="medium">medium</prosody> rate 3
       </speak>
     `;
 
@@ -46,9 +46,8 @@ describe('rate-standard-medium', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
@@ -56,6 +55,7 @@ describe('rate-standard-medium', () => {
       <speak>
       A medium rate 1
       A medium rate 2
+      A medium rate 3
       </speak>
     `;
 
@@ -63,38 +63,36 @@ describe('rate-standard-medium', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
       A medium rate 1
       A medium rate 2
+      A medium rate 3
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('rate-standard-x-slow', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     A (xslow)[rate:"x-slow"] rate
+    A (xslow)[rate:'x-slow'] rate
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="x-slow">xslow</prosody> rate
       A <prosody rate="x-slow">xslow</prosody> rate
       </speak>
     `;
@@ -103,14 +101,14 @@ describe('rate-standard-x-slow', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="x-slow">xslow</prosody> rate
       A <prosody rate="x-slow">xslow</prosody> rate
       </speak>
     `;
@@ -119,14 +117,14 @@ describe('rate-standard-x-slow', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A xslow rate
       A xslow rate
       </speak>
     `;
@@ -135,37 +133,35 @@ describe('rate-standard-x-slow', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      A xslow rate
       A xslow rate
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('rate-standard-slow', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     A (slow)[rate:"slow"] rate
+    A (slow)[rate:'slow'] rate
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="slow">slow</prosody> rate
       A <prosody rate="slow">slow</prosody> rate
       </speak>
     `;
@@ -174,14 +170,14 @@ describe('rate-standard-slow', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="slow">slow</prosody> rate
       A <prosody rate="slow">slow</prosody> rate
       </speak>
     `;
@@ -190,14 +186,14 @@ describe('rate-standard-slow', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A slow rate
       A slow rate
       </speak>
     `;
@@ -206,37 +202,35 @@ describe('rate-standard-slow', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      A slow rate
       A slow rate
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('rate-standard-x-fast', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     A (xfast)[rate:"x-fast"] rate
+    A (xfast)[rate:'x-fast'] rate
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="x-fast">xfast</prosody> rate
       A <prosody rate="x-fast">xfast</prosody> rate
       </speak>
     `;
@@ -245,14 +239,14 @@ describe('rate-standard-x-fast', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="x-fast">xfast</prosody> rate
       A <prosody rate="x-fast">xfast</prosody> rate
       </speak>
     `;
@@ -261,14 +255,14 @@ describe('rate-standard-x-fast', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A xfast rate
       A xfast rate
       </speak>
     `;
@@ -277,37 +271,35 @@ describe('rate-standard-x-fast', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      A xfast rate
       A xfast rate
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('rate-standard-fast', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     A (fast)[rate:"fast"] rate
+    A (fast)[rate:'fast'] rate
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="fast">fast</prosody> rate
       A <prosody rate="fast">fast</prosody> rate
       </speak>
     `;
@@ -316,14 +308,14 @@ describe('rate-standard-fast', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A <prosody rate="fast">fast</prosody> rate
       A <prosody rate="fast">fast</prosody> rate
       </speak>
     `;
@@ -332,14 +324,14 @@ describe('rate-standard-fast', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      A fast rate
       A fast rate
       </speak>
     `;
@@ -348,16 +340,14 @@ describe('rate-standard-fast', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      A fast rate
       A fast rate
     `;
 
     expect(text).toBe(expected);
   });
-
 });

--- a/tests/say-as-modifiers.spec.ts
+++ b/tests/say-as-modifiers.spec.ts
@@ -3,22 +3,22 @@ import dedent from 'ts-dedent';
 import { SpeechMarkdown } from '../src/SpeechMarkdown';
 
 describe('say-as-modifiers last modifier wins', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     Some (text)[address;number;time:"hms12";date;chars]
+    Some (text)[address;number;time:'hms12';date;chars]
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Some <say-as interpret-as="characters">text</say-as>
       Some <say-as interpret-as="characters">text</say-as>
       </speak>
     `;
@@ -27,14 +27,14 @@ describe('say-as-modifiers last modifier wins', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Some <say-as interpret-as="characters">text</say-as>
       Some <say-as interpret-as="characters">text</say-as>
       </speak>
     `;
@@ -43,14 +43,14 @@ describe('say-as-modifiers last modifier wins', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Some <say-as interpret-as="spell-out">text</say-as>
       Some <say-as interpret-as="spell-out">text</say-as>
       </speak>
     `;
@@ -59,16 +59,14 @@ describe('say-as-modifiers last modifier wins', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      Some text
       Some text
     `;
 
     expect(text).toBe(expected);
   });
-
 });

--- a/tests/sub-standard.spec.ts
+++ b/tests/sub-standard.spec.ts
@@ -3,23 +3,23 @@ import dedent from 'ts-dedent';
 import { SpeechMarkdown } from '../src/SpeechMarkdown';
 
 describe('sub-standard', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     The element is (Al)[sub:"aluminum"].
+    Visit our website at (www.speechmarkdown.org)[sub:"speech mark down dot org"].
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
       The element is <sub alias="aluminum">Al</sub>.
+      Visit our website at <sub alias="speech mark down dot org">www.speechmarkdown.org</sub>.
       </speak>
     `;
 
@@ -27,15 +27,15 @@ describe('sub-standard', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
       The element is <sub alias="aluminum">Al</sub>.
+      Visit our website at <sub alias="speech mark down dot org">www.speechmarkdown.org</sub>.
       </speak>
     `;
 
@@ -43,15 +43,15 @@ describe('sub-standard', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
       The element is <sub alias="aluminum">Al</sub>.
+      Visit our website at <sub alias="speech mark down dot org">www.speechmarkdown.org</sub>.
       </speak>
     `;
 
@@ -59,16 +59,14 @@ describe('sub-standard', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
       The element is Al.
+      Visit our website at www.speechmarkdown.org.
     `;
 
     expect(text).toBe(expected);
   });
-
 });

--- a/tests/voice-standard.spec.ts
+++ b/tests/voice-standard.spec.ts
@@ -3,22 +3,22 @@ import dedent from 'ts-dedent';
 import { SpeechMarkdown } from '../src/SpeechMarkdown';
 
 describe('voice-standard', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     Why do you keep switching voices (from one)[voice:"Brian"] to (the other)[voice:"Kendra"]?
+    Why do you keep switching voices (from one)[voice:'Brian'] to (the other)[voice:'Kendra']?
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices <voice name="Brian">from one</voice> to <voice name="Kendra">the other</voice>?
       Why do you keep switching voices <voice name="Brian">from one</voice> to <voice name="Kendra">the other</voice>?
       </speak>
     `;
@@ -27,14 +27,14 @@ describe('voice-standard', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -43,14 +43,14 @@ describe('voice-standard', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -59,37 +59,35 @@ describe('voice-standard', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('voice-standard lowercase name', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     Why do you keep switching voices (from one)[voice:"brian"] to (the other)[voice:"kendra"]?
+    Why do you keep switching voices (from one)[voice:'brian'] to (the other)[voice:'kendra']?
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices <voice name="Brian">from one</voice> to <voice name="Kendra">the other</voice>?
       Why do you keep switching voices <voice name="Brian">from one</voice> to <voice name="Kendra">the other</voice>?
       </speak>
     `;
@@ -98,14 +96,14 @@ describe('voice-standard lowercase name', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -114,14 +112,14 @@ describe('voice-standard lowercase name', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -130,37 +128,35 @@ describe('voice-standard lowercase name', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('voice-standard invalid name', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     Why do you keep switching voices (from one)[voice:"brianzzzz"] to (the other)[voice:"kendra"]?
+    Why do you keep switching voices (from one)[voice:'brianzzzz'] to (the other)[voice:'kendra']?
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to <voice name="Kendra">the other</voice>?
       Why do you keep switching voices from one to <voice name="Kendra">the other</voice>?
       </speak>
     `;
@@ -169,14 +165,14 @@ describe('voice-standard invalid name', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -185,14 +181,14 @@ describe('voice-standard invalid name', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -201,37 +197,35 @@ describe('voice-standard invalid name', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
     `;
 
     expect(text).toBe(expected);
   });
-
 });
 
 describe('voice-standard device name', () => {
-
   const speech = new SpeechMarkdown();
 
   const markdown = dedent`
     Why do you keep switching voices (from one)[voice:"device"] to (the other)[voice:"kendra"]?
+    Why do you keep switching voices (from one)[voice:'device'] to (the other)[voice:'kendra']?
   `;
 
   test('converts to SSML - Amazon Alexa', () => {
-
     const options = {
-      platform: 'amazon-alexa'
+      platform: 'amazon-alexa',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to <voice name="Kendra">the other</voice>?
       Why do you keep switching voices from one to <voice name="Kendra">the other</voice>?
       </speak>
     `;
@@ -240,14 +234,14 @@ describe('voice-standard device name', () => {
   });
 
   test('converts to SSML - Google Assistant', () => {
-
     const options = {
-      platform: 'google-assistant'
+      platform: 'google-assistant',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -256,14 +250,14 @@ describe('voice-standard device name', () => {
   });
 
   test('converts to SSML - Samsung Bixby', () => {
-
     const options = {
-      platform: 'samsung-bixby'
+      platform: 'samsung-bixby',
     };
     const ssml = speech.toSSML(markdown, options);
 
     const expected = dedent`
       <speak>
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
       </speak>
     `;
@@ -272,16 +266,14 @@ describe('voice-standard device name', () => {
   });
 
   test('converts to Plain Text', () => {
-
-    const options = {
-    };
+    const options = {};
     const text = speech.toText(markdown, options);
 
     const expected = dedent`
+      Why do you keep switching voices from one to the other?
       Why do you keep switching voices from one to the other?
     `;
 
     expect(text).toBe(expected);
   });
-
 });


### PR DESCRIPTION
Including the single quote character in the ipa character set caused issues with parsing single-quoted strings. Removing the single quote character from single-quoted strings addresses the issue.

See update to SpeechMarkdownGrammar.ts

Also updated numerous voice, rate, and pitch tests to validate single quotes.

There is still an issue with using single quote characters in single-quoted IPA strings. For example:
```
I say, <phoneme alphabet="ipa" ph="'pi.kæn">pecan</phoneme>.   WORKS
```

```
I say, <phoneme alphabet='ipa' ph='\'pi.kæn'>pecan</phoneme>. DOES NOT WORK
```

However, the above sample didn't work previously. 