### PR TITLE
Added Google support for ipa and lang

### DIFF
--- a/src/formatters/GoogleAssistantSsmlFormatter.ts
+++ b/src/formatters/GoogleAssistantSsmlFormatter.ts
@@ -8,6 +8,7 @@ export class GoogleAssistantSsmlFormatter extends SsmlFormatterBase {
 
     this.modifierKeyToSsmlTagMappings.interjection = null;
     this.modifierKeyToSsmlTagMappings.whisper = 'prosody';
+    this.modifierKeyToSsmlTagMappings.lang = 'lang';
   }
 
   // tslint:disable-next-line: max-func-body-length
@@ -84,11 +85,10 @@ export class GoogleAssistantSsmlFormatter extends SsmlFormatterBase {
             }
 
             case 'ipa': {
-              // Google Assistant does not support <phoneme> tag
               if (!textModifierObject.tags[ssmlTag]) {
                 textModifierObject.tags[ssmlTag] = { sortId: sortId, attrs: null };
               }
-              textModifierObject['textOnly'] = true;
+              textModifierObject.tags[ssmlTag].attrs = { alphabet: key, ph: value };
               break;
             }
 
@@ -112,6 +112,14 @@ export class GoogleAssistantSsmlFormatter extends SsmlFormatterBase {
               attrs[key] = value || 'medium';
               textModifierObject.tags[ssmlTag].attrs = { ...textModifierObject.tags[ssmlTag].attrs, ...attrs };
 
+              break;
+            }
+
+            case 'lang': {
+              if (!textModifierObject.tags[ssmlTag]) {
+                textModifierObject.tags[ssmlTag] = { sortId: sortId, attrs: null };
+              }
+              textModifierObject.tags[ssmlTag].attrs = { 'xml:lang': value };
               break;
             }
 

--- a/tests/ipa-standard-alphabet-uk.spec.ts
+++ b/tests/ipa-standard-alphabet-uk.spec.ts
@@ -35,7 +35,7 @@ describe('ipa-standard-alphabet-uk', () => {
 
     const expected = dedent`
       <speak>
-      I say, ipa.
+      I say, <phoneme alphabet="ipa" ph="ˈˌb.d.f.g.h.j.k.l.m.n.p.s.t.v.w.z.i.u.æ.ð.ʃ.θ.ʒ.ə.aɪ.aʊ.ɑ.eɪ.ɝ.ɛ.ɪ.əʊ.ɔ.ɔɪ.ʊ.ʌ.ɒ.ɛə.ɪə.ʊə.ŋ.ɹ.d͡ʒ.t͡ʃ">ipa</phoneme>.
       </speak>
     `;
 

--- a/tests/ipa-standard-alphabet-us.spec.ts
+++ b/tests/ipa-standard-alphabet-us.spec.ts
@@ -35,7 +35,7 @@ describe('ipa-standard-alphabet-us', () => {
 
     const expected = dedent`
       <speak>
-      I say, ipa.
+      I say, <phoneme alphabet="ipa" ph="ˈˌb.d.f.g.h.j.k.l.m.n.p.s.t.v.w.z.i.u.æ.ð.ʃ.θ.ʒ.ə.ɚ.aɪ.aʊ.ɑ.eɪ.ɝ.ɛ.ɪ.oʊ.ɔ.ɔɪ.ʊ.ʌ.ŋ.ɹ.d͡ʒ.t͡ʃ">ipa</phoneme>.
       </speak>
     `;
 

--- a/tests/ipa-standard.spec.ts
+++ b/tests/ipa-standard.spec.ts
@@ -32,7 +32,7 @@ describe('ipa-standard', () => {
 
     const expected = dedent`
       <speak>
-      I say, pecan.
+      I say, <phoneme alphabet="ipa" ph="'pi.kæn">pecan</phoneme>.
       </speak>
     `;
 

--- a/tests/lang-standard.spec.ts
+++ b/tests/lang-standard.spec.ts
@@ -34,8 +34,8 @@ describe('lang-standard', () => {
 
     const expected = dedent`
       <speak>
-      In Paris, they pronounce it Paris.
-      In Paris, they pronounce it Paris.
+      In Paris, they pronounce it <lang xml:lang="fr-FR">Paris</lang>.
+      In Paris, they pronounce it <lang xml:lang="fr-FR">Paris</lang>.
       </speak>
     `;
 


### PR DESCRIPTION
Google Assistant now supports <phoneme> and <lang>, so added support in the Google Assistant SSML formatter